### PR TITLE
Enable dynamic email display and offer PDF download

### DIFF
--- a/api/Controllers/OffersController.cs
+++ b/api/Controllers/OffersController.cs
@@ -219,4 +219,34 @@ public class OffersController : ControllerBase
             Data = null
         });
     }
+
+    [HttpGet("{id}/pdf")]
+    public async Task<IActionResult> GetOfferPdf(int id)
+    {
+        var userId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        if (userId == null)
+        {
+            return BadRequest(new BaseResponse<string>
+            {
+                Success = false,
+                StatusCode = 400,
+                Message = "Geçersiz kullanıcı",
+                Data = null
+            });
+        }
+
+        var pdf = await _offerService.GetOfferPdfAsync(id, userId);
+        if (pdf == null)
+        {
+            return NotFound(new BaseResponse<string>
+            {
+                Success = false,
+                StatusCode = 404,
+                Message = "Teklif bulunamadı",
+                Data = null
+            });
+        }
+
+        return File(pdf, "application/pdf", $"teklif-{id}.pdf");
+    }
 }

--- a/api/Services/EmailService.cs
+++ b/api/Services/EmailService.cs
@@ -23,10 +23,10 @@ public class EmailService : IEmailService
         var body = GenerateOfferEmailBody(offer);
         var pdf = GenerateOfferPdf(offer);
 
-        return await SendEmailAsync(offer.CustomerEmail, subject, body, pdf, $"{offer.OfferNumber}.pdf");
+        return await SendEmailAsync(offer.CustomerEmail, subject, body, pdf, $"{offer.OfferNumber}.pdf", offer);
     }
 
-    public async Task<bool> SendEmailAsync(string to, string subject, string body, byte[]? attachmentData = null, string? attachmentName = null)
+    public async Task<bool> SendEmailAsync(string to, string subject, string body, byte[]? attachmentData = null, string? attachmentName = null, Offer? offer = null)
     {
         try
         {
@@ -41,15 +41,24 @@ public class EmailService : IEmailService
                 EnableSsl = true
             };
 
+            var displayName = offer != null
+                ? $"{offer.User.FirstName} {offer.User.LastName} | {offer.Company.Name}"
+                : "Teklif Sistemi";
+
             var message = new MailMessage
             {
-                From = new MailAddress(username!, "Teklif Sistemi"),
+                From = new MailAddress(username!, displayName),
                 Subject = subject,
                 Body = body,
                 IsBodyHtml = true
             };
 
             message.To.Add(to);
+
+            if (offer != null && !string.IsNullOrWhiteSpace(offer.User.Email))
+            {
+                message.ReplyToList.Add(new MailAddress(offer.User.Email));
+            }
 
             if (attachmentData != null)
             {

--- a/api/Services/IEmailService.cs
+++ b/api/Services/IEmailService.cs
@@ -5,5 +5,5 @@ namespace OfferManagement.API.Services;
 public interface IEmailService
 {
     Task<bool> SendOfferEmailAsync(Offer offer);
-    Task<bool> SendEmailAsync(string to, string subject, string body, byte[]? attachmentData = null, string? attachmentName = null);
+    Task<bool> SendEmailAsync(string to, string subject, string body, byte[]? attachmentData = null, string? attachmentName = null, Offer? offer = null);
 }

--- a/api/Services/IOfferService.cs
+++ b/api/Services/IOfferService.cs
@@ -11,4 +11,5 @@ public interface IOfferService
     Task<OfferDto?> UpdateOfferAsync(int id, UpdateOfferRequest request);
     Task<bool> DeleteOfferAsync(int id, string userId);
     Task<bool> SendOfferAsync(int id, string userId);
+    Task<byte[]?> GetOfferPdfAsync(int id, string userId);
 }

--- a/api/Services/OfferService.cs
+++ b/api/Services/OfferService.cs
@@ -4,6 +4,9 @@ using OfferManagement.API.Data;
 using OfferManagement.API.DTOs;
 using OfferManagement.API.Models;
 using System.ComponentModel.Design;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
 
 namespace OfferManagement.API.Services;
 
@@ -183,6 +186,7 @@ public class OfferService : IOfferService
         var offer = await _context.Offers
             .Include(o => o.Items)
             .Include(o => o.Company)
+            .Include(o => o.User)
             .FirstOrDefaultAsync(o => o.Id == id && o.UserId == userId);
 
         if (offer == null) return false;
@@ -195,6 +199,18 @@ public class OfferService : IOfferService
         }
 
         return emailSent;
+    }
+
+    public async Task<byte[]?> GetOfferPdfAsync(int id, string userId)
+    {
+        var offer = await _context.Offers
+            .Include(o => o.Items)
+            .Include(o => o.Company)
+            .FirstOrDefaultAsync(o => o.Id == id && o.UserId == userId);
+
+        if (offer == null) return null;
+
+        return GenerateOfferPdf(offer);
     }
 
     private string GenerateOfferNumber(string? lastOfferNumber)
@@ -241,5 +257,131 @@ public class OfferService : IOfferService
                 TotalPrice = item.TotalPrice
             }).ToList()
         };
+    }
+
+    private byte[] GenerateOfferPdf(Offer offer)
+    {
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(20);
+                page.DefaultTextStyle(TextStyle.Default.FontSize(11).FontFamily("Helvetica"));
+                page.Background(Colors.White);
+
+                page.Header().Background(Colors.Grey.Lighten3).Padding(10).Row(row =>
+                {
+                    var logoPath = "wwwroot/" + offer?.Company?.Logo;
+                    if (!string.IsNullOrWhiteSpace(offer?.Company?.Logo) && System.IO.File.Exists(logoPath))
+                    {
+                        row.ConstantColumn(120).Height(80).Image(logoPath, ImageScaling.FitArea);
+                    }
+
+                    row.RelativeColumn().AlignRight().Column(col =>
+                    {
+                        col.Item().Text(offer.Company.Name).FontSize(18).Bold();
+                        col.Item().Text(offer.Company.Address);
+                        col.Item().Text($"Tel: {offer.Company.Phone}");
+                        col.Item().Text($"E-posta: {offer.Company.Email}");
+                    });
+                });
+
+                page.Content().PaddingVertical(10).Column(column =>
+                {
+                    column.Spacing(15);
+
+                    column.Item().AlignCenter().Text($"Teklif: {offer.OfferNumber}").Bold().FontSize(20);
+
+                    column.Item().Row(row =>
+                    {
+                        row.RelativeColumn().Column(col =>
+                        {
+                            col.Item().Text("TEKLİF BİLGİLERİ").Bold().FontSize(12).Underline();
+                            col.Item().Text($"Teklif No: {offer.OfferNumber}");
+                            col.Item().Text($"Tarih: {offer.OfferDate:dd.MM.yyyy}");
+                        });
+
+                        row.RelativeColumn().Column(col =>
+                        {
+                            col.Item().Text("MÜŞTERİ BİLGİLERİ").Bold().FontSize(12).Underline();
+                            col.Item().Text(offer.CustomerName);
+                            col.Item().Text(offer.CustomerAddress);
+                        });
+                    });
+
+                    column.Item().PaddingVertical(10).LineHorizontal(1).LineColor(Colors.Grey.Medium);
+
+                    column.Item().Table(table =>
+                    {
+                        table.ColumnsDefinition(columns =>
+                        {
+                            columns.RelativeColumn(4);
+                            columns.RelativeColumn(1);
+                            columns.RelativeColumn(2);
+                            columns.RelativeColumn(2);
+                        });
+
+                        table.Header(header =>
+                        {
+                            header.Cell().Element(HeaderCell).Text("Ürün Açıklaması");
+                            header.Cell().Element(HeaderCell).AlignCenter().Text("Adet");
+                            header.Cell().Element(HeaderCell).AlignRight().Text("Birim Fiyat");
+                            header.Cell().Element(HeaderCell).AlignRight().Text("Tutar");
+                        });
+
+                        foreach (var item in offer.Items)
+                        {
+                            table.Cell().Element(DataCell).Text(item.Description);
+                            table.Cell().Element(DataCell).AlignCenter().Text(item.Quantity.ToString());
+                            table.Cell().Element(DataCell).AlignRight().Text(item.UnitPrice.ToString("C"));
+                            table.Cell().Element(DataCell).AlignRight().Text(item.TotalPrice.ToString("C"));
+                        }
+
+                        table.Footer(footer =>
+                        {
+                            footer.Cell().ColumnSpan(3).Element(DataCell).AlignRight().Text("Ara Toplam").Bold();
+                            footer.Cell().Element(DataCell).AlignRight().Text((offer.TotalAmount * 0.82m).ToString("C")).Bold();
+
+                            footer.Cell().ColumnSpan(3).Element(DataCell).AlignRight().Text("KDV %18").Bold();
+                            footer.Cell().Element(DataCell).AlignRight().Text((offer.TotalAmount * 0.18m).ToString("C")).Bold();
+
+                            footer.Cell().ColumnSpan(3).Element(DataCell).AlignRight().Text("Genel Toplam").Bold().FontSize(11);
+                            footer.Cell().Element(DataCell).AlignRight().Text(offer.TotalAmount.ToString("C")).Bold().FontSize(11);
+                        });
+
+                        static IContainer HeaderCell(IContainer container) =>
+                            container.PaddingVertical(5).PaddingLeft(5).Background("#eeeeee").BorderBottom(1).BorderColor(Colors.Grey.Medium).DefaultTextStyle(TextStyle.Default.SemiBold().FontSize(11));
+
+                        static IContainer DataCell(IContainer container) =>
+                            container.PaddingVertical(4).PaddingLeft(5).BorderBottom(1).BorderColor(Colors.Grey.Lighten2).DefaultTextStyle(TextStyle.Default.FontSize(10));
+                    });
+
+                    column.Item().PaddingTop(20).Row(row =>
+                    {
+                        row.RelativeColumn().Text("Not: Bu teklif belge niteliğindedir. Siparişe dönüşmeden fatura oluşturulmaz.")
+                            .Italic().FontSize(9);
+
+                        row.ConstantColumn(200).Column(col =>
+                        {
+                            col.Item().Text("Yetkili İmza").AlignRight().FontSize(10).Bold();
+                            col.Item().Height(40);
+                            col.Item().Container().AlignRight().Width(150).LineHorizontal(1);
+                        });
+                    });
+                });
+
+                page.Footer().PaddingTop(10).LineHorizontal(1).LineColor(Colors.Grey.Lighten2);
+                page.Footer().AlignRight().Text(text =>
+                {
+                    text.Span("Sayfa ").FontSize(9);
+                    text.CurrentPageNumber();
+                    text.Span(" / ");
+                    text.TotalPages();
+                });
+            });
+        });
+
+        return document.GeneratePdf();
     }
 }

--- a/ui/app/dashboard/offers/[id]/page.tsx
+++ b/ui/app/dashboard/offers/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useOfferStore } from '@/store/offerStore';
-import { ArrowLeft, Edit, Send } from 'lucide-react';
+import { ArrowLeft, Edit, Send, Download } from 'lucide-react';
 import { format } from 'date-fns';
 import { tr } from 'date-fns/locale';
 import ConfirmDialog from '@/components/ConfirmDialog';
@@ -14,7 +14,7 @@ export default function OfferDetailPage() {
   const router = useRouter();
   const params = useParams();
   const id = Number(params.id);
-  const { currentOffer: offer, fetchOffer, sendOffer, loading } = useOfferStore();
+  const { currentOffer: offer, fetchOffer, sendOffer, downloadOfferPdf, loading } = useOfferStore();
   const [sendDialogOpen, setSendDialogOpen] = useState(false);
 
   useEffect(() => {
@@ -169,17 +169,22 @@ export default function OfferDetailPage() {
         </div>
       </div>
 
-      {offer.status !== 'Sent' && (
-        <div className="flex justify-end">
-          <button
-            onClick={() => setSendDialogOpen(true)}
-            className="btn btn-primary btn-md"
-          >
-            <Send className="h-4 w-4 mr-2" />
-            Teklifi Gönder
-          </button>
-        </div>
-      )}
+      <div className="flex justify-end space-x-2">
+        <button
+          onClick={() => downloadOfferPdf(id)}
+          className="btn btn-outline btn-md"
+        >
+          <Download className="h-4 w-4 mr-2" />
+          PDF Gör
+        </button>
+        <button
+          onClick={() => setSendDialogOpen(true)}
+          className="btn btn-primary btn-md"
+        >
+          <Send className="h-4 w-4 mr-2" />
+          Teklifi Gönder
+        </button>
+      </div>
 
       <ConfirmDialog
         isOpen={sendDialogOpen}

--- a/ui/app/dashboard/offers/page.tsx
+++ b/ui/app/dashboard/offers/page.tsx
@@ -24,7 +24,7 @@ import toast from 'react-hot-toast';
 
 export default function OffersPage() {
   const router = useRouter();
-  const { offers, fetchOffers, deleteOffer, sendOffer, loading } = useOfferStore();
+  const { offers, fetchOffers, deleteOffer, sendOffer, downloadOfferPdf, loading } = useOfferStore();
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -238,18 +238,23 @@ export default function OffersPage() {
                           >
                             <Edit className="h-4 w-4" />
                           </button>
-                          {offer.status !== 'Sent' && (
-                            <button
-                              onClick={() => {
-                                setOfferToSend(offer.id);
-                                setSendDialogOpen(true);
-                              }}
-                              className="text-green-400 hover:text-green-600"
-                              title="Gönder"
-                            >
-                              <Send className="h-4 w-4" />
-                            </button>
-                          )}
+                          <button
+                            onClick={() => {
+                              setOfferToSend(offer.id);
+                              setSendDialogOpen(true);
+                            }}
+                            className="text-green-400 hover:text-green-600"
+                            title="Gönder"
+                          >
+                            <Send className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={() => downloadOfferPdf(offer.id)}
+                            className="text-indigo-400 hover:text-indigo-600"
+                            title="PDF"
+                          >
+                            <Download className="h-4 w-4" />
+                          </button>
                           <button
                             onClick={() => {
                               setSelectedOfferId(offer.id);

--- a/ui/store/offerStore.ts
+++ b/ui/store/offerStore.ts
@@ -55,6 +55,7 @@ interface OfferState {
   updateOffer: (id: number, data: CreateOfferData) => Promise<Offer>;
   deleteOffer: (id: number) => Promise<void>;
   sendOffer: (id: number) => Promise<void>;
+  downloadOfferPdf: (id: number) => Promise<void>;
   setCurrentOffer: (offer: Offer | null) => void;
 }
 
@@ -159,6 +160,16 @@ export const useOfferStore = create<OfferState>((set, get) => ({
       }));
     } catch (error: any) {
       throw new Error(error.response?.data?.message || 'Teklif gönderilemedi');
+    }
+  },
+
+  downloadOfferPdf: async (id: number) => {
+    try {
+      const response = await api.get(`/api/offers/${id}/pdf`, { responseType: 'blob' });
+      const url = window.URL.createObjectURL(new Blob([response.data], { type: 'application/pdf' }));
+      window.open(url, '_blank');
+    } catch (error: any) {
+      throw new Error(error.response?.data?.message || 'PDF indirilemedi');
     }
   },
 


### PR DESCRIPTION
## Summary
- personalize `From` display and Reply-To when sending offers
- expose offer PDF generation from API
- add button to view offer PDF without sending mail
- keep Send button always visible on offer pages

## Testing
- `dotnet build -nologo`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68766fdc3318832dbb0246ba696d561f