### PR TITLE
Implement public PDF sharing and WhatsApp link

### DIFF
--- a/api/Controllers/OffersController.cs
+++ b/api/Controllers/OffersController.cs
@@ -357,4 +357,23 @@ public class OffersController : ControllerBase
 
         return File(pdf, "application/pdf", $"teklif-{id}.pdf");
     }
+
+    [AllowAnonymous]
+    [HttpGet("pdf/{id}.pdf")]
+    public async Task<IActionResult> GetOfferPdfPublic(int id)
+    {
+        var pdf = await _offerService.GetOfferPdfPublicAsync(id);
+        if (pdf == null)
+        {
+            return NotFound(new BaseResponse<string>
+            {
+                Success = false,
+                StatusCode = 404,
+                Message = "Teklif bulunamadı",
+                Data = null
+            });
+        }
+
+        return File(pdf, "application/pdf", $"teklif-{id}.pdf");
+    }
 }

--- a/api/Services/IOfferService.cs
+++ b/api/Services/IOfferService.cs
@@ -15,4 +15,5 @@ public interface IOfferService
     Task<bool> RejectOfferAsync(int id, string userId);
     Task<bool> CancelOfferAsync(int id, string userId);
     Task<byte[]?> GetOfferPdfAsync(int id, string userId);
+    Task<byte[]?> GetOfferPdfPublicAsync(int id);
 }

--- a/api/Services/OfferService.cs
+++ b/api/Services/OfferService.cs
@@ -248,6 +248,25 @@ public class OfferService : IOfferService
         return GenerateOfferPdf(offer);
     }
 
+    public async Task<byte[]?> GetOfferPdfPublicAsync(int id)
+    {
+        var offer = await _context.Offers
+            .Include(o => o.Items)
+            .Include(o => o.Company)
+            .Include(o => o.User)
+            .FirstOrDefaultAsync(o => o.Id == id);
+
+        if (offer == null) return null;
+
+        if (offer.Status == OfferStatus.Sent)
+        {
+            offer.Status = OfferStatus.Viewed;
+            await _context.SaveChangesAsync();
+        }
+
+        return GenerateOfferPdf(offer);
+    }
+
     private string GenerateOfferNumber(string? lastOfferNumber)
     {
         if (string.IsNullOrEmpty(lastOfferNumber))

--- a/ui/app/dashboard/offers/page.tsx
+++ b/ui/app/dashboard/offers/page.tsx
@@ -4,17 +4,20 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useOfferStore } from '@/store/offerStore';
 import { 
-  Plus, 
-  Search, 
-  Filter, 
-  Eye, 
-  Edit, 
-  Trash2, 
+  Plus,
+  Search,
+  Filter,
+  Eye,
+  Edit,
+  Trash2,
   Send,
   Download,
   Calendar,
   User,
-  DollarSign
+  DollarSign,
+  MessageCircle,
+  Check,
+  X
 } from 'lucide-react';
 import { format } from 'date-fns';
 import { tr } from 'date-fns/locale';
@@ -24,7 +27,7 @@ import toast from 'react-hot-toast';
 
 export default function OffersPage() {
   const router = useRouter();
-  const { offers, fetchOffers, deleteOffer, sendOffer, downloadOfferPdf, loading } = useOfferStore();
+  const { offers, fetchOffers, deleteOffer, sendOffer, downloadOfferPdf, acceptOffer, rejectOffer, loading } = useOfferStore();
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -66,6 +69,15 @@ export default function OffersPage() {
     } catch (error: any) {
       toast.error(error.message);
     }
+  };
+
+  const handleShareWhatsapp = (offer: typeof offers[0]) => {
+    const pdfLink = `${window.location.origin}/teklifler/pdf/${offer.id}.pdf`;
+    const mesaj = `Merhaba, size özel teklifiniz hazırlandı. İncelemek için tıklayın:\n${pdfLink}`;
+    const whatsappLink = offer.customerPhone
+      ? `https://wa.me/${offer.customerPhone}?text=${encodeURIComponent(mesaj)}`
+      : `https://wa.me/?text=${encodeURIComponent(mesaj)}`;
+    window.open(whatsappLink, '_blank');
   };
 
   const getStatusColor = (status: string) => {
@@ -229,7 +241,7 @@ export default function OffersPage() {
                         </div>
                       </td>
                       <td className="table-cell">
-                        <div className="flex items-center space-x-2">
+                        <div className="flex flex-wrap items-center gap-2">
                           <button
                             onClick={() => router.push(`/dashboard/offers/${offer.id}`)}
                             className="text-gray-400 hover:text-gray-600"
@@ -261,6 +273,39 @@ export default function OffersPage() {
                           >
                             <Download className="h-4 w-4" />
                           </button>
+                          <button
+                            onClick={() => handleShareWhatsapp(offer)}
+                            className="text-green-600 hover:text-green-800"
+                            title="WhatsApp"
+                          >
+                            <MessageCircle className="h-4 w-4" />
+                          </button>
+                          {offer.status !== 'Accepted' && (
+                            <button
+                              onClick={() => {
+                                if (confirm('Teklifi onaylamak istediğinize emin misiniz?')) {
+                                  acceptOffer(offer.id);
+                                }
+                              }}
+                              className="text-green-400 hover:text-green-600"
+                              title="Onayla"
+                            >
+                              <Check className="h-4 w-4" />
+                            </button>
+                          )}
+                          {offer.status !== 'Rejected' && (
+                            <button
+                              onClick={() => {
+                                if (confirm('Teklifi reddetmek istediğinize emin misiniz?')) {
+                                  rejectOffer(offer.id);
+                                }
+                              }}
+                              className="text-red-400 hover:text-red-600"
+                              title="Reddet"
+                            >
+                              <X className="h-4 w-4" />
+                            </button>
+                          )}
                           <button
                             onClick={() => {
                               setSelectedOfferId(offer.id);

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -10,6 +10,10 @@ const nextConfig = {
         source: '/api/:path*',
         destination: `${process.env.NEXT_PUBLIC_API_URL}/api/:path*`,
       },
+      {
+        source: '/teklifler/pdf/:id.pdf',
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/api/offers/pdf/:id.pdf`,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary
- add a public PDF endpoint that marks offers as viewed
- expose new service method for public PDF downloads
- add rewrite so `/teklifler/pdf/:id.pdf` forwards to API
- provide WhatsApp share, accept and reject actions in offers list

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68767ac56ba8832dafcd82a26f31a148