### PR TITLE
Add dropdown actions and pdf route

### DIFF
--- a/ui/app/teklifler/pdf/[id].pdf/route.ts
+++ b/ui/app/teklifler/pdf/[id].pdf/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://localhost:53759';
+  const url = `${API_BASE_URL}/api/offers/pdf/${params.id}.pdf`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    return new NextResponse('Internal Server Error', { status: res.status });
+  }
+
+  const data = await res.arrayBuffer();
+  return new NextResponse(data, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `inline; filename="teklif-${params.id}.pdf"`,
+    },
+  });
+}

--- a/ui/components/ConfirmDialog.tsx
+++ b/ui/components/ConfirmDialog.tsx
@@ -11,7 +11,7 @@ interface ConfirmDialogProps {
   message: string;
   confirmText?: string;
   cancelText?: string;
-  type?: 'danger' | 'warning' | 'info';
+  type?: 'danger' | 'warning' | 'info' | 'success';
   children?: ReactNode;
 }
 
@@ -44,6 +44,11 @@ export default function ConfirmDialog({
         return {
           icon: 'text-blue-600',
           button: 'bg-blue-600 hover:bg-blue-700 text-white',
+        };
+      case 'success':
+        return {
+          icon: 'text-green-600',
+          button: 'bg-green-600 hover:bg-green-700 text-white',
         };
       default:
         return {

--- a/ui/components/OfferActionsDropdown.tsx
+++ b/ui/components/OfferActionsDropdown.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Eye,
+  Edit,
+  Send,
+  Download,
+  MessageCircle,
+  Check,
+  X,
+  Trash2,
+  MoreVertical,
+} from 'lucide-react';
+
+interface Props {
+  onView: () => void;
+  onEdit: () => void;
+  onSend: () => void;
+  onPdf: () => void;
+  onWhatsapp: () => void;
+  onAccept?: () => void;
+  onReject?: () => void;
+  onDelete: () => void;
+  showAccept: boolean;
+  showReject: boolean;
+}
+
+export default function OfferActionsDropdown({
+  onView,
+  onEdit,
+  onSend,
+  onPdf,
+  onWhatsapp,
+  onAccept,
+  onReject,
+  onDelete,
+  showAccept,
+  showReject,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  const toggle = () => setOpen(!open);
+  const handle = (fn: () => void) => {
+    fn();
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative inline-block text-left">
+      <button onClick={toggle} className="p-2 text-gray-400 hover:text-gray-600">
+        <MoreVertical className="h-4 w-4" />
+      </button>
+      {open && (
+        <div className="origin-top-right absolute right-0 mt-2 w-40 rounded-md shadow-lg bg-white dark:bg-gray-700 ring-1 ring-black ring-opacity-5 z-10">
+          <div className="py-1">
+            <button onClick={() => handle(onView)} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-600">
+              <Eye className="h-4 w-4 mr-2" />Görüntüle
+            </button>
+            <button onClick={() => handle(onEdit)} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-600">
+              <Edit className="h-4 w-4 mr-2" />Düzenle
+            </button>
+            <button onClick={() => handle(onSend)} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-600">
+              <Send className="h-4 w-4 mr-2" />Gönder
+            </button>
+            <button onClick={() => handle(onPdf)} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-600">
+              <Download className="h-4 w-4 mr-2" />PDF
+            </button>
+            <button onClick={() => handle(onWhatsapp)} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-600">
+              <MessageCircle className="h-4 w-4 mr-2" />WhatsApp
+            </button>
+            {showAccept && onAccept && (
+              <button onClick={() => handle(onAccept)} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-600">
+                <Check className="h-4 w-4 mr-2" />Onayla
+              </button>
+            )}
+            {showReject && onReject && (
+              <button onClick={() => handle(onReject)} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-600">
+                <X className="h-4 w-4 mr-2" />Reddet
+              </button>
+            )}
+            <button onClick={() => handle(onDelete)} className="flex items-center w-full px-4 py-2 text-sm text-red-600 hover:bg-gray-100 dark:hover:bg-gray-600">
+              <Trash2 className="h-4 w-4 mr-2" />Sil
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `OfferActionsDropdown` component
- extend `ConfirmDialog` to support success dialogs
- group actions in `/dashboard/offers` under dropdown
- add confirmation modals for accept/reject
- serve PDFs via dynamic route

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687680d7c5dc832da27fed989b923869