### PR TITLE
Switch discounts to percentage rates

### DIFF
--- a/api/DTOs/OfferDTOs.cs
+++ b/api/DTOs/OfferDTOs.cs
@@ -28,6 +28,7 @@ public class OfferItemDto
     public string Description { get; set; } = string.Empty;
     public int Quantity { get; set; }
     public decimal UnitPrice { get; set; }
+    // Discount rate (e.g. 5 for %5)
     public decimal Discount { get; set; }
     public decimal VatRate { get; set; }
     public decimal TotalPrice { get; set; }
@@ -51,6 +52,7 @@ public class CreateOfferItemRequest
     public string Description { get; set; } = string.Empty;
     public int Quantity { get; set; } = 1;
     public decimal UnitPrice { get; set; }
+    // Discount rate (e.g. 5 for %5)
     public decimal Discount { get; set; } = 0m;
     public decimal VatRate { get; set; } = 0m;
 }

--- a/api/Models/Offer.cs
+++ b/api/Models/Offer.cs
@@ -61,7 +61,7 @@ public class OfferItem
 
     public decimal UnitPrice { get; set; }
 
-    // Discount amount applied to this item
+    // Discount rate applied to this item (e.g. 5 for %5)
     public decimal Discount { get; set; } = 0m;
 
     // VAT rate for this item (e.g. 20 for %20)

--- a/ui/app/dashboard/offers/[id]/edit/page.tsx
+++ b/ui/app/dashboard/offers/[id]/edit/page.tsx
@@ -85,7 +85,8 @@ export default function EditOfferPage() {
     };
 
     if (field === 'quantity' || field === 'unitPrice' || field === 'discount') {
-      newItems[index].totalPrice = newItems[index].quantity * newItems[index].unitPrice - newItems[index].discount;
+      newItems[index].totalPrice =
+        newItems[index].quantity * newItems[index].unitPrice * (1 - newItems[index].discount / 100);
     }
 
     setItems(newItems);
@@ -101,8 +102,22 @@ export default function EditOfferPage() {
     }
   };
 
-  const getTotalAmount = () => {
-    return items.reduce((sum, item) => sum + item.totalPrice * (1 + item.vatRate / 100), 0);
+  const calculateTotals = () => {
+    const totalBeforeDiscount = items.reduce(
+      (sum, item) => sum + item.quantity * item.unitPrice,
+      0
+    );
+    const discountTotal = items.reduce(
+      (sum, item) => sum + item.quantity * item.unitPrice * (item.discount / 100),
+      0
+    );
+    const subTotal = totalBeforeDiscount - discountTotal;
+    const vatTotal = items.reduce(
+      (sum, item) => sum + item.totalPrice * (item.vatRate / 100),
+      0
+    );
+    const grandTotal = subTotal + vatTotal;
+    return { totalBeforeDiscount, discountTotal, subTotal, vatTotal, grandTotal };
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -316,7 +331,7 @@ export default function EditOfferPage() {
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">İndirim</label>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">İndirim %</label>
                       <input
                         type="number"
                         step="0.01"
@@ -363,17 +378,58 @@ export default function EditOfferPage() {
             </div>
 
             <div className="mt-6 pt-4 border-t">
-              <div className="flex justify-end">
-                <div className="text-right">
-                  <p className="text-sm text-gray-600">Toplam Tutar</p>
-                  <p className="text-2xl font-bold text-gray-900">
-                    {getTotalAmount().toLocaleString('tr-TR', {
-                      style: 'currency',
-                      currency: formData.currency,
-                    })}
-                  </p>
-                </div>
-              </div>
+              {(() => {
+                const totals = calculateTotals();
+                return (
+                  <div className="space-y-1 text-right">
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">Ara Toplam:</span>
+                      <span className="font-medium">
+                        {totals.totalBeforeDiscount.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: formData.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">İndirim:</span>
+                      <span className="font-medium">
+                        {totals.discountTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: formData.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">Ara Toplam (İndirimli):</span>
+                      <span className="font-medium">
+                        {totals.subTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: formData.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">KDV:</span>
+                      <span className="font-medium">
+                        {totals.vatTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: formData.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div className="pt-1 border-t">
+                      <p className="text-sm text-gray-600">Genel Toplam</p>
+                      <p className="text-2xl font-bold text-gray-900">
+                        {totals.grandTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: formData.currency,
+                        })}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })()}
             </div>
           </div>
         </div>

--- a/ui/app/dashboard/offers/[id]/page.tsx
+++ b/ui/app/dashboard/offers/[id]/page.tsx
@@ -162,7 +162,9 @@ export default function OfferDetailPage() {
                     <th className="table-head">Açıklama</th>
                     <th className="table-head">Adet</th>
                     <th className="table-head">Birim Fiyat</th>
-                    <th className="table-head">Toplam</th>
+                    <th className="table-head">İndirim %</th>
+                    <th className="table-head">KDV %</th>
+                    <th className="table-head">Tutar</th>
                   </tr>
                 </thead>
                 <tbody className="table-body">
@@ -176,6 +178,8 @@ export default function OfferDetailPage() {
                           currency: offer.currency,
                         })}
                       </td>
+                      <td className="table-cell">{item.discount.toLocaleString('tr-TR')}%</td>
+                      <td className="table-cell">{item.vatRate}</td>
                       <td className="table-cell">
                         {item.totalPrice.toLocaleString('tr-TR', {
                           style: 'currency',
@@ -188,15 +192,71 @@ export default function OfferDetailPage() {
               </table>
             </div>
             <div className="flex justify-end mt-4">
-              <div className="text-right">
-                <p className="text-sm text-gray-600">Toplam Tutar</p>
-                <p className="text-2xl font-bold text-gray-900">
-                  {offer.totalAmount.toLocaleString('tr-TR', {
-                    style: 'currency',
-                    currency: offer.currency,
-                  })}
-                </p>
-              </div>
+              {(() => {
+                const totalBeforeDiscount = offer.items.reduce(
+                  (s, i) => s + i.quantity * i.unitPrice,
+                  0
+                );
+                const discountTotal = offer.items.reduce(
+                  (s, i) => s + i.quantity * i.unitPrice * (i.discount / 100),
+                  0
+                );
+                const subTotal = totalBeforeDiscount - discountTotal;
+                const vatTotal = offer.items.reduce(
+                  (s, i) => s + i.totalPrice * (i.vatRate / 100),
+                  0
+                );
+                const grandTotal = subTotal + vatTotal;
+                return (
+                  <div className="space-y-1 text-right">
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">Ara Toplam:</span>
+                      <span className="font-medium">
+                        {totalBeforeDiscount.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">İndirim:</span>
+                      <span className="font-medium">
+                        {discountTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">Ara Toplam (İndirimli):</span>
+                      <span className="font-medium">
+                        {subTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">KDV:</span>
+                      <span className="font-medium">
+                        {vatTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div className="pt-1 border-t">
+                      <p className="text-sm text-gray-600">Genel Toplam</p>
+                      <p className="text-2xl font-bold text-gray-900">
+                        {grandTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })()}
             </div>
           </div>
         </div>

--- a/ui/app/public-offer/[token]/page.tsx
+++ b/ui/app/public-offer/[token]/page.tsx
@@ -129,7 +129,9 @@ export default function PublicOfferPage() {
                     <th className="table-head">Açıklama</th>
                     <th className="table-head">Adet</th>
                     <th className="table-head">Birim Fiyat</th>
-                    <th className="table-head">Toplam</th>
+                    <th className="table-head">İndirim %</th>
+                    <th className="table-head">KDV %</th>
+                    <th className="table-head">Tutar</th>
                   </tr>
                 </thead>
                 <tbody className="table-body">
@@ -143,6 +145,8 @@ export default function PublicOfferPage() {
                           currency: offer.currency,
                         })}
                       </td>
+                      <td className="table-cell">{item.discount.toLocaleString('tr-TR')}%</td>
+                      <td className="table-cell">{item.vatRate}</td>
                       <td className="table-cell">
                         {item.totalPrice.toLocaleString('tr-TR', {
                           style: 'currency',
@@ -155,15 +159,71 @@ export default function PublicOfferPage() {
               </table>
             </div>
             <div className="flex justify-end mt-4">
-              <div className="text-right">
-                <p className="text-sm text-gray-600">Toplam Tutar</p>
-                <p className="text-2xl font-bold">
-                  {offer.totalAmount.toLocaleString('tr-TR', {
-                    style: 'currency',
-                    currency: offer.currency,
-                  })}
-                </p>
-              </div>
+              {(() => {
+                const totalBeforeDiscount = offer.items.reduce(
+                  (s, i) => s + i.quantity * i.unitPrice,
+                  0
+                );
+                const discountTotal = offer.items.reduce(
+                  (s, i) => s + i.quantity * i.unitPrice * (i.discount / 100),
+                  0
+                );
+                const subTotal = totalBeforeDiscount - discountTotal;
+                const vatTotal = offer.items.reduce(
+                  (s, i) => s + i.totalPrice * (i.vatRate / 100),
+                  0
+                );
+                const grandTotal = subTotal + vatTotal;
+                return (
+                  <div className="space-y-1 text-right">
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">Ara Toplam:</span>
+                      <span className="font-medium">
+                        {totalBeforeDiscount.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">İndirim:</span>
+                      <span className="font-medium">
+                        {discountTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">Ara Toplam (İndirimli):</span>
+                      <span className="font-medium">
+                        {subTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-sm text-gray-600 mr-2">KDV:</span>
+                      <span className="font-medium">
+                        {vatTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </span>
+                    </div>
+                    <div className="pt-1 border-t">
+                      <p className="text-sm text-gray-600">Genel Toplam</p>
+                      <p className="text-2xl font-bold">
+                        {grandTotal.toLocaleString('tr-TR', {
+                          style: 'currency',
+                          currency: offer.currency,
+                        })}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })()}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- treat discounts as percentages across the API and UI
- recalc totals in services and display VAT and discount amounts
- update offer creation, editing, detail and public pages with new totals
- adjust PDF generation for discount percentage

## Testing
- `npm install`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68775f679354832dad26debd3efe598a