### PR TITLE
Improve dark mode and disable duplicate subscriptions

### DIFF
--- a/ui/app/dashboard/billing/page.tsx
+++ b/ui/app/dashboard/billing/page.tsx
@@ -246,7 +246,7 @@ export default function BillingPage() {
                 className={`relative border-2 rounded-lg p-6 ${
                   plan.popular
                     ? 'border-primary-500 bg-primary-50'
-                    : 'border-gray-200 bg-white'
+                    : 'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800'
                 }`}
               >
                 {plan.popular && (
@@ -281,8 +281,16 @@ export default function BillingPage() {
                 
                 <div className="mt-6">
                   <button
-                    onClick={() => handlePlanSelect(plan.name, plan.price)}
-                    disabled={processing && selectedPlan?.name === plan.name}
+                    onClick={() =>
+                      company?.subscriptionPlan.toLowerCase() !==
+                        plan.name.toLowerCase() &&
+                      handlePlanSelect(plan.name, plan.price)
+                    }
+                    disabled={
+                      (processing && selectedPlan?.name === plan.name) ||
+                      company?.subscriptionPlan.toLowerCase() ===
+                        plan.name.toLowerCase()
+                    }
                     className={`w-full btn btn-md ${
                       plan.popular
                         ? 'btn-primary'

--- a/ui/app/dashboard/customers/CustomersClient.tsx
+++ b/ui/app/dashboard/customers/CustomersClient.tsx
@@ -179,7 +179,7 @@ export default function CustomersClient() {
       {/* Create Modal */}
       {showCreateModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Yeni Müşteri</h3>
             <form onSubmit={handleCreate} className="space-y-4">
               <div>
@@ -247,7 +247,7 @@ export default function CustomersClient() {
       {/* Edit Modal */}
       {showEditModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Müşteriyi Düzenle</h3>
             <form onSubmit={handleUpdate} className="space-y-4">
               <div>

--- a/ui/app/dashboard/offers/[id]/page.tsx
+++ b/ui/app/dashboard/offers/[id]/page.tsx
@@ -16,6 +16,7 @@ export default function OfferDetailPage() {
   const id = Number(params.id);
   const { currentOffer: offer, fetchOffer, sendOffer, downloadOfferPdf, acceptOffer, rejectOffer, cancelOffer, loading } = useOfferStore();
   const [sendDialogOpen, setSendDialogOpen] = useState(false);
+  const [sending, setSending] = useState(false);
   const [acceptDialogOpen, setAcceptDialogOpen] = useState(false);
   const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
@@ -27,12 +28,15 @@ export default function OfferDetailPage() {
   }, [fetchOffer, id]);
 
   const handleSendOffer = async () => {
+    setSending(true);
     try {
       await sendOffer(id);
       toast.success('Teklif gönderildi');
       setSendDialogOpen(false);
     } catch (error: any) {
       toast.error(error.message);
+    } finally {
+      setSending(false);
     }
   };
 
@@ -313,6 +317,7 @@ export default function OfferDetailPage() {
         title="Teklifi Gönder"
         message="Teklifi müşteriye göndermek istediğinizden emin misiniz?"
         confirmText="Gönder"
+        processing={sending}
         type="info"
       />
       <ConfirmDialog

--- a/ui/app/dashboard/offers/page.tsx
+++ b/ui/app/dashboard/offers/page.tsx
@@ -27,6 +27,7 @@ export default function OffersPage() {
   const [selectedOfferId, setSelectedOfferId] = useState<number | null>(null);
   const [sendDialogOpen, setSendDialogOpen] = useState(false);
   const [offerToSend, setOfferToSend] = useState<number | null>(null);
+  const [sending, setSending] = useState(false);
   const [acceptDialogOpen, setAcceptDialogOpen] = useState(false);
   const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
   const [offerToAccept, setOfferToAccept] = useState<number | null>(null);
@@ -58,6 +59,7 @@ export default function OffersPage() {
 
   const handleSendOffer = async () => {
     if (!offerToSend) return;
+    setSending(true);
     try {
       await sendOffer(offerToSend);
       toast.success('Teklif gönderildi');
@@ -65,6 +67,8 @@ export default function OffersPage() {
       setOfferToSend(null);
     } catch (error: any) {
       toast.error(error.message);
+    } finally {
+      setSending(false);
     }
   };
 
@@ -315,6 +319,7 @@ export default function OffersPage() {
         title="Teklifi Gönder"
         message="Teklifi müşteriye göndermek istediğinizden emin misiniz?"
         confirmText="Gönder"
+        processing={sending}
         type="info"
       />
       <ConfirmDialog

--- a/ui/app/dashboard/products/ProductsClient.tsx
+++ b/ui/app/dashboard/products/ProductsClient.tsx
@@ -156,7 +156,7 @@ export default function ProductsClient() {
 
       {showCreateModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Yeni Ürün</h3>
             <form onSubmit={handleCreate} className="space-y-4">
               <div>
@@ -218,7 +218,7 @@ export default function ProductsClient() {
 
       {showEditModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Ürünü Düzenle</h3>
             <form onSubmit={handleUpdate} className="space-y-4">
               <div>

--- a/ui/app/dashboard/users/UsersClient.tsx
+++ b/ui/app/dashboard/users/UsersClient.tsx
@@ -189,7 +189,7 @@ export default function UsersClient() {
       {/* Create User Modal */}
       {showCreateModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Yeni Kullanıcı Ekle</h3>
 
             <form onSubmit={handleCreateUser} className="space-y-4">

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -120,3 +120,10 @@
     @apply p-4 align-middle [&:has([role=checkbox])]:pr-0;
   }
 }
+
+@layer utilities {
+  .dark .bg-white { @apply bg-gray-800; }
+  .dark .text-gray-900 { @apply text-gray-100; }
+  .dark .text-gray-600 { @apply text-gray-300; }
+  .dark .text-gray-500 { @apply text-gray-400; }
+}

--- a/ui/app/login/page.tsx
+++ b/ui/app/login/page.tsx
@@ -50,7 +50,7 @@ export default function LoginPage() {
       </div>
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
+        <div className="bg-white dark:bg-gray-800 py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-gray-700">

--- a/ui/app/register/page.tsx
+++ b/ui/app/register/page.tsx
@@ -80,7 +80,7 @@ export default function RegisterPage() {
       </div>
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
+        <div className="bg-white dark:bg-gray-800 py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div>

--- a/ui/components/ConfirmDialog.tsx
+++ b/ui/components/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode } from 'react';
+import LoadingSpinner from './LoadingSpinner';
 import { AlertTriangle, X } from 'lucide-react';
 
 interface ConfirmDialogProps {
@@ -12,6 +13,7 @@ interface ConfirmDialogProps {
   confirmText?: string;
   cancelText?: string;
   type?: 'danger' | 'warning' | 'info' | 'success';
+  processing?: boolean;
   children?: ReactNode;
 }
 
@@ -24,6 +26,7 @@ export default function ConfirmDialog({
   confirmText = 'Onayla',
   cancelText = 'İptal',
   type = 'danger',
+  processing = false,
   children,
 }: ConfirmDialogProps) {
   if (!isOpen) return null;
@@ -90,9 +93,11 @@ export default function ConfirmDialog({
           </button>
           <button
             onClick={onConfirm}
+            disabled={processing}
             className={`btn btn-md ${typeStyles.button}`}
           >
-            {confirmText}
+            {processing && <LoadingSpinner size="sm" className="mr-2" />}
+            {processing ? 'İşleniyor...' : confirmText}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- support dark mode colors globally
- make auth pages and modals use dark mode backgrounds
- prevent subscribing to the same plan again
- add spinner support in confirmation dialog
- show spinner while sending offers

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6877d0f2eccc832d8f592ffb06c5a1c1